### PR TITLE
Fix #6025: RPC stuck when two clients

### DIFF
--- a/packages/platform-node/test/RpcServer.test.ts
+++ b/packages/platform-node/test/RpcServer.test.ts
@@ -2,9 +2,9 @@ import { HttpClient, HttpClientRequest, HttpRouter, HttpServer, SocketServer } f
 import { NodeHttpServer, NodeSocket, NodeSocketServer, NodeWorker } from "@effect/platform-node"
 import { RpcClient, RpcSerialization, RpcServer } from "@effect/rpc"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Logger } from "effect"
 import * as CP from "node:child_process"
-import { RpcLive, User, UsersClient } from "./fixtures/rpc-schemas.js"
+import { AuthClient, RpcLive, User, UsersClient, SecondRpcClient } from "./fixtures/rpc-schemas.js"
 import { e2eSuite } from "./rpc-e2e.js"
 
 describe("RpcServer", () => {
@@ -147,5 +147,37 @@ describe("RpcServer", () => {
         const user = yield* client.GetUser({ id: "1" })
         assert.deepStrictEqual(user, new User({ id: "1", name: "Logged in user" }))
       }).pipe(Effect.provide(UsersClient.layerTest)))
+  })
+
+  /**
+   * Regression test for #6025: RpcClient gets stuck when created twice from different layers.
+   * When multiple Layer.scoped each provide an RpcClient (or one layer + RpcClient.make()),
+   * both share the same Protocol. The Protocol's run() used to allow only one active
+   * callback (semaphore 1), so the second client would block forever or responses would
+   * go to the wrong client. This test ensures two clients from the same Protocol both work.
+   */
+  describe("issue #6025 - RpcClient from layer and from make()", { timeout: 30_000 }, () => {
+    const layer = Layer.merge(UsersClient.layer, SecondRpcClient.layer).pipe(
+      Layer.provide(
+        Layer.merge(
+          RpcClient.layerProtocolHttp({
+            url: "",
+            transformClient: HttpClient.mapRequest(HttpClientRequest.appendUrl("/rpc"))
+          }),
+          AuthClient
+        )
+      ),
+      Layer.provideMerge(HttpNdjsonServer),
+      Layer.provide([NodeHttpServer.layerTest, RpcSerialization.layerNdjson])
+    )
+
+    it.effect("second RpcClient (from layer) completes and RPC resolves when layer already provides a client", () =>
+      Effect.gen(function*() {
+        const clientFromLayer = yield* UsersClient
+        const secondClient = yield* SecondRpcClient
+        const user = yield* secondClient.GetUser({ id: "1" })
+        assert.instanceOf(user, User)
+        assert.deepStrictEqual(user, new User({ id: "1", name: "Logged in user" }))
+      }).pipe(Effect.provide(layer)))
   })
 })

--- a/packages/platform-node/test/RpcServer.test.ts
+++ b/packages/platform-node/test/RpcServer.test.ts
@@ -2,9 +2,9 @@ import { HttpClient, HttpClientRequest, HttpRouter, HttpServer, SocketServer } f
 import { NodeHttpServer, NodeSocket, NodeSocketServer, NodeWorker } from "@effect/platform-node"
 import { RpcClient, RpcSerialization, RpcServer } from "@effect/rpc"
 import { assert, describe, it } from "@effect/vitest"
-import { Effect, Layer, Logger } from "effect"
+import { Effect, Layer } from "effect"
 import * as CP from "node:child_process"
-import { AuthClient, RpcLive, User, UsersClient, SecondRpcClient } from "./fixtures/rpc-schemas.js"
+import { AuthClient, RpcLive, SecondRpcClient, User, UsersClient } from "./fixtures/rpc-schemas.js"
 import { e2eSuite } from "./rpc-e2e.js"
 
 describe("RpcServer", () => {
@@ -173,7 +173,7 @@ describe("RpcServer", () => {
 
     it.effect("second RpcClient (from layer) completes and RPC resolves when layer already provides a client", () =>
       Effect.gen(function*() {
-        const clientFromLayer = yield* UsersClient
+        yield* UsersClient
         const secondClient = yield* SecondRpcClient
         const user = yield* secondClient.GetUser({ id: "1" })
         assert.instanceOf(user, User)

--- a/packages/platform-node/test/fixtures/rpc-schemas.ts
+++ b/packages/platform-node/test/fixtures/rpc-schemas.ts
@@ -154,7 +154,7 @@ export const RpcLive = RpcServer.layer(UserRpcs).pipe(
   ])
 )
 
-const AuthClient = RpcMiddleware.layerClient(AuthMiddleware, ({ request }) =>
+export const AuthClient = RpcMiddleware.layerClient(AuthMiddleware, ({ request }) =>
   Effect.succeed({
     ...request,
     headers: Headers.set(request.headers, "name", "Logged in user")
@@ -169,5 +169,15 @@ export class UsersClient extends Context.Tag("UsersClient")<
   )
   static layerTest = Layer.scoped(UsersClient, RpcTest.makeClient(UserRpcs)).pipe(
     Layer.provide([UsersLive, AuthLive, TimingLive, AuthClient])
+  )
+}
+
+/** Second RpcClient sharing the same Protocol - used for #6025 regression test */
+export class SecondRpcClient extends Context.Tag("SecondRpcClient")<
+  SecondRpcClient,
+  RpcClient.RpcClient<RpcGroup.Rpcs<typeof UserRpcs>, RpcClientError>
+>() {
+  static layer = Layer.scoped(SecondRpcClient, RpcClient.make(UserRpcs)).pipe(
+    Layer.provide(AuthClient)
   )
 }

--- a/packages/rpc/src/internal/utils.ts
+++ b/packages/rpc/src/internal/utils.ts
@@ -1,5 +1,5 @@
-import type * as Context from "effect/Context"
 import * as Cause from "effect/Cause"
+import type * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 
 /** @internal */
@@ -23,7 +23,10 @@ export const withRun = <
               Effect.runSync(
                 Effect.provide(fn(...args), subscriberContext).pipe(
                   Effect.catchAllCause((cause) =>
-                    Effect.logError("RpcClient Protocol: subscriber delivery failed (other subscribers still receive message)", cause).pipe(
+                    Effect.logError(
+                      "RpcClient Protocol: subscriber delivery failed (other subscribers still receive message)",
+                      cause
+                    ).pipe(
                       Effect.asVoid
                     )
                   )

--- a/packages/rpc/src/internal/utils.ts
+++ b/packages/rpc/src/internal/utils.ts
@@ -1,4 +1,5 @@
 import type * as Context from "effect/Context"
+import * as Cause from "effect/Cause"
 import * as Effect from "effect/Effect"
 
 /** @internal */
@@ -9,29 +10,50 @@ export const withRun = <
 >() =>
 <EX, RX>(f: (write: Parameters<A["run"]>[0]) => Effect.Effect<Omit<A, "run">, EX, RX>): Effect.Effect<A, EX, RX> =>
   Effect.suspend(() => {
-    const semaphore = Effect.unsafeMakeSemaphore(1)
     let buffer: Array<[Array<any>, Context.Context<never>]> = []
-    let write = (...args: Array<any>): Effect.Effect<void> =>
-      Effect.contextWith((context) => {
-        buffer.push([args, context])
+    const subscriberEntries = new Map<
+      (...args: Array<any>) => Effect.Effect<void>,
+      Context.Context<never>
+    >()
+    const write = (...args: Array<any>): Effect.Effect<void> =>
+      Effect.contextWith((_writeContext) => {
+        if (subscriberEntries.size > 0) {
+          for (const [fn, subscriberContext] of subscriberEntries.entries()) {
+            try {
+              Effect.runSync(
+                Effect.provide(fn(...args), subscriberContext).pipe(
+                  Effect.catchAllCause((cause) =>
+                    Effect.logError("RpcClient Protocol: subscriber delivery failed (other subscribers still receive message)", cause).pipe(
+                      Effect.asVoid
+                    )
+                  )
+                )
+              )
+            } catch (defect) {
+              Effect.runSync(Effect.logError("RpcClient Protocol: subscriber delivery threw", Cause.die(defect)))
+            }
+          }
+          return Effect.void
+        }
+        buffer.push([args, _writeContext])
+        return Effect.void
       })
     return Effect.map(f((...args) => write(...args)), (a) => ({
       ...a,
-      run(f) {
-        return semaphore.withPermits(1)(Effect.gen(function*() {
-          const prev = write
-          write = f
-
+      run(fn) {
+        return Effect.gen(function*() {
+          const subscriberContext = yield* Effect.context<never>()
+          subscriberEntries.set(fn, subscriberContext)
           for (const [args, context] of buffer) {
-            yield* Effect.provide(write(...args), context)
+            yield* Effect.provide(fn(...args), context)
           }
           buffer = []
 
           return yield* Effect.onExit(Effect.never, () => {
-            write = prev
+            subscriberEntries.delete(fn)
             return Effect.void
           })
-        }))
+        })
       }
     } as A))
   })

--- a/packages/rpc/test/RpcClient.test.ts
+++ b/packages/rpc/test/RpcClient.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit test for #6025: two RpcClients sharing one Protocol both receive responses.
+ * Uses a fake Protocol (no HTTP/TCP) so the test passes regardless of environment.
+ */
+import { Rpc, RpcClient, RpcGroup } from "@effect/rpc"
+import type { RpcClientError } from "@effect/rpc/RpcClientError"
+import * as RpcClientModule from "@effect/rpc/RpcClient"
+import type { FromClientEncoded, FromServerEncoded } from "@effect/rpc/RpcMessage"
+import { assert, describe, it } from "@effect/vitest"
+import { Context, Effect, Layer, Schema } from "effect"
+
+const GetUser = Rpc.make("GetUser", {
+  success: Schema.Struct({ id: Schema.String, name: Schema.String }),
+  payload: Schema.Struct({ id: Schema.String })
+})
+
+const TestRpcs = RpcGroup.make(GetUser)
+
+class FirstClient extends Context.Tag("FirstClient")<
+  FirstClient,
+  RpcClient.RpcClient<RpcGroup.Rpcs<typeof TestRpcs>, RpcClientError>
+>() {
+  static layer = Layer.scoped(FirstClient, RpcClient.make(TestRpcs))
+}
+
+class SecondClient extends Context.Tag("SecondClient")<
+  SecondClient,
+  RpcClient.RpcClient<RpcGroup.Rpcs<typeof TestRpcs>, RpcClientError>
+>() {
+  static layer = Layer.scoped(SecondClient, RpcClient.make(TestRpcs))
+}
+
+function makeFakeProtocolLayer(): Layer.Layer<RpcClientModule.Protocol> {
+  return Layer.effect(
+    RpcClientModule.Protocol,
+    RpcClientModule.Protocol.make(
+      Effect.fnUntraced(function*(writeResponse) {
+        return {
+          send: (request: FromClientEncoded): Effect.Effect<void> => {
+            if (request._tag !== "Request") return Effect.void
+            return writeResponse({
+              _tag: "Exit",
+              requestId: request.id,
+              exit: {
+                _tag: "Success",
+                value: { id: "1", name: "TestUser" }
+              }
+            } as FromServerEncoded)
+          },
+          supportsAck: false,
+          supportsTransferables: false
+        }
+      })
+    )
+  )
+}
+
+const layer = Layer.merge(FirstClient.layer, SecondClient.layer).pipe(
+  Layer.provide(makeFakeProtocolLayer())
+)
+
+describe("RpcClient", () => {
+  describe("issue #6025 - two clients sharing one Protocol", { timeout: 15_000 }, () => {
+    it.effect("two clients can be acquired from one Protocol (no hang on layer build)", () =>
+      Effect.scoped(
+        Effect.gen(function*() {
+          const first = yield* FirstClient
+          const second = yield* SecondClient
+          assert.ok(first)
+          assert.ok(second)
+        }).pipe(Effect.provide(layer))
+      ))
+
+    it.effect("second client GetUser completes when two clients share the same Protocol", () =>
+      Effect.scoped(
+        Effect.gen(function*() {
+          const _first = yield* FirstClient
+          const second = yield* SecondClient
+          const user = yield* second.GetUser({ id: "1" })
+          assert.deepStrictEqual(user, { id: "1", name: "TestUser" })
+        }).pipe(Effect.provide(layer))
+      ))
+  })
+})

--- a/packages/rpc/test/RpcClient.test.ts
+++ b/packages/rpc/test/RpcClient.test.ts
@@ -3,8 +3,8 @@
  * Uses a fake Protocol (no HTTP/TCP) so the test passes regardless of environment.
  */
 import { Rpc, RpcClient, RpcGroup } from "@effect/rpc"
-import type { RpcClientError } from "@effect/rpc/RpcClientError"
 import * as RpcClientModule from "@effect/rpc/RpcClient"
+import type { RpcClientError } from "@effect/rpc/RpcClientError"
 import type { FromClientEncoded, FromServerEncoded } from "@effect/rpc/RpcMessage"
 import { assert, describe, it } from "@effect/vitest"
 import { Context, Effect, Layer, Schema } from "effect"
@@ -74,7 +74,7 @@ describe("RpcClient", () => {
     it.effect("second client GetUser completes when two clients share the same Protocol", () =>
       Effect.scoped(
         Effect.gen(function*() {
-          const _first = yield* FirstClient
+          yield* FirstClient
           const second = yield* SecondClient
           const user = yield* second.GetUser({ id: "1" })
           assert.deepStrictEqual(user, { id: "1", name: "TestUser" })


### PR DESCRIPTION

## Summary

Fixes https://github.com/Smerly/effect-ts-clone/issues/2

Fixes RpcClient getting stuck when two clients are created from different layers and share one Protocol. Both clients can now acquire and complete RPC calls (e.g. `GetUser`) when they use the same Protocol instance.

---

## Key changes

Implements the intended Protocol behavior for multiple subscribers and response delivery.

### Protocol (multi-subscriber and delivery)

**Multi-subscriber support**

- Replaces the single-callback/semaphore in `withRun` with a `Map` of subscribers (`subscriberEntries`).
- Multiple clients can call `protocol.run()` and subscribe without blocking each other.

**Synchronous delivery**

- Delivers to subscribers with:

```ts
Effect.runSync(
  Effect.provide(fn(...args), subscriberContext)
)