### PR TITLE
Fix #6052: @effect/platform: Nested anyOf emitted for flat union payloads in OpenAPI output

### DIFF
--- a/packages/platform/src/HttpApiSchema.ts
+++ b/packages/platform/src/HttpApiSchema.ts
@@ -240,6 +240,18 @@ export const UnionUnifyAST = (self: AST.AST, that: AST.AST): AST.AST =>
   AST.Union.make(Array.from(new Set<AST.AST>([...extractUnionTypes(self), ...extractUnionTypes(that)])))
 
 /**
+ * Flattens Union ASTs (including nested) into a single Union so OpenAPI emits one anyOf array.
+ * Uses existing extractUnionTypes; no special-casing. Idempotent for already-flat unions.
+ * @internal
+ */
+export const flattenUnionAST = (ast: AST.AST): AST.AST => {
+  if (!AST.isUnion(ast)) return ast
+  const types = Array.from(extractUnionTypes(ast))
+  if (types.length <= 1) return ast
+  return AST.annotations(AST.Union.make(types), ast.annotations)
+}
+
+/**
  * @since 1.0.0
  */
 export const UnionUnify = <A extends Schema.Schema.All, B extends Schema.Schema.All>(self: A, that: B): Schema.Schema<

--- a/packages/platform/src/OpenApi.ts
+++ b/packages/platform/src/OpenApi.ts
@@ -253,7 +253,7 @@ export const fromApi = <Id extends string, Groups extends HttpApiGroup.Any, E, R
   }
 
   function processAST(ast: AST.AST): JsonSchema.JsonSchema {
-    return JsonSchema.fromAST(ast, {
+    return JsonSchema.fromAST(HttpApiSchema.flattenUnionAST(ast), {
       defs: jsonSchemaDefs,
       additionalPropertiesStrategy: options?.additionalPropertiesStrategy
     })

--- a/packages/platform/test/OpenApi.test.ts
+++ b/packages/platform/test/OpenApi.test.ts
@@ -1814,7 +1814,8 @@ describe("OpenApi", () => {
           )
         )
         const nestedSpec = OpenApi.fromApi(nestedApi)
-        const nestedRequestBodySchema = nestedSpec.paths["/bar-nested"]?.post?.requestBody?.content?.["application/json"]?.schema
+        const nestedBarPath = nestedSpec.paths["/bar-nested"]?.post?.requestBody?.content
+        const nestedRequestBodySchema = nestedBarPath?.["application/json"]?.schema
         deepStrictEqual(nestedRequestBodySchema !== undefined, true)
         const nestedAnyOf = (nestedRequestBodySchema as { anyOf?: Array<unknown> }).anyOf
         deepStrictEqual(Array.isArray(nestedAnyOf), true)

--- a/packages/platform/test/OpenApi.test.ts
+++ b/packages/platform/test/OpenApi.test.ts
@@ -1797,7 +1797,7 @@ describe("OpenApi", () => {
         const spec = OpenApi.fromApi(api)
         const requestBodySchema = spec.paths["/bar"]?.post?.requestBody?.content?.["application/json"]?.schema
         deepStrictEqual(requestBodySchema !== undefined, true)
-        const anyOf = (requestBodySchema as { anyOf?: unknown[] }).anyOf
+        const anyOf = (requestBodySchema as { anyOf?: Array<unknown> }).anyOf
         deepStrictEqual(Array.isArray(anyOf), true)
         deepStrictEqual(anyOf!.length, expectedCount)
         const hasNestedAnyOf = anyOf!.some(
@@ -1814,10 +1814,9 @@ describe("OpenApi", () => {
           )
         )
         const nestedSpec = OpenApi.fromApi(nestedApi)
-        const nestedRequestBodySchema =
-          nestedSpec.paths["/bar-nested"]?.post?.requestBody?.content?.["application/json"]?.schema
+        const nestedRequestBodySchema = nestedSpec.paths["/bar-nested"]?.post?.requestBody?.content?.["application/json"]?.schema
         deepStrictEqual(nestedRequestBodySchema !== undefined, true)
-        const nestedAnyOf = (nestedRequestBodySchema as { anyOf?: unknown[] }).anyOf
+        const nestedAnyOf = (nestedRequestBodySchema as { anyOf?: Array<unknown> }).anyOf
         deepStrictEqual(Array.isArray(nestedAnyOf), true)
         deepStrictEqual(nestedAnyOf!.length, expectedCount)
         const nestedHasNestedAnyOf = nestedAnyOf!.some(

--- a/packages/platform/test/OpenApi.test.ts
+++ b/packages/platform/test/OpenApi.test.ts
@@ -1777,6 +1777,55 @@ describe("OpenApi", () => {
         })
       })
 
+      // #6052: Union payload must produce a single flat anyOf array (all members at top level), not nested anyOf.
+      // Run with: pnpm --filter @effect/platform test -- --run -t "6052"
+      // If this test fails (e.g. anyOf.length !== expected or hasNestedAnyOf), the bug is present.
+      it("flat union payload emits flat anyOf in request body (#6052)", () => {
+        const A = Schema.Struct({ _tag: Schema.Literal("A"), a: Schema.String })
+        const B = Schema.Struct({ _tag: Schema.Literal("B"), b: Schema.Number })
+        const C = Schema.Struct({ _tag: Schema.Literal("C"), c: Schema.Boolean })
+        const members = [A, B, C] as const
+        const expectedCount = members.length
+
+        const api = HttpApi.make("api").add(
+          HttpApiGroup.make("group").add(
+            HttpApiEndpoint.post("post", "/bar")
+              .addSuccess(Schema.String)
+              .setPayload(Schema.Union(...members))
+          )
+        )
+        const spec = OpenApi.fromApi(api)
+        const requestBodySchema = spec.paths["/bar"]?.post?.requestBody?.content?.["application/json"]?.schema
+        deepStrictEqual(requestBodySchema !== undefined, true)
+        const anyOf = (requestBodySchema as { anyOf?: unknown[] }).anyOf
+        deepStrictEqual(Array.isArray(anyOf), true)
+        deepStrictEqual(anyOf!.length, expectedCount)
+        const hasNestedAnyOf = anyOf!.some(
+          (member) => typeof member === "object" && member !== null && "anyOf" in member
+        )
+        deepStrictEqual(hasNestedAnyOf, false)
+
+        // Nested union must also produce flat anyOf (validates flattening, not just already-flat input)
+        const nestedApi = HttpApi.make("api").add(
+          HttpApiGroup.make("group").add(
+            HttpApiEndpoint.post("postNested", "/bar-nested")
+              .addSuccess(Schema.String)
+              .setPayload(Schema.Union(Schema.Union(A, B), C))
+          )
+        )
+        const nestedSpec = OpenApi.fromApi(nestedApi)
+        const nestedRequestBodySchema =
+          nestedSpec.paths["/bar-nested"]?.post?.requestBody?.content?.["application/json"]?.schema
+        deepStrictEqual(nestedRequestBodySchema !== undefined, true)
+        const nestedAnyOf = (nestedRequestBodySchema as { anyOf?: unknown[] }).anyOf
+        deepStrictEqual(Array.isArray(nestedAnyOf), true)
+        deepStrictEqual(nestedAnyOf!.length, expectedCount)
+        const nestedHasNestedAnyOf = nestedAnyOf!.some(
+          (member) => typeof member === "object" && member !== null && "anyOf" in member
+        )
+        deepStrictEqual(nestedHasNestedAnyOf, false)
+      })
+
       it("Multipart", () => {
         const api = HttpApi.make("api").add(
           HttpApiGroup.make("group").add(


### PR DESCRIPTION
Fixes https://github.com/Smerly/effect-ts-clone/issues/3

Fixes OpenAPI emitting nested anyOf for Schema.Union payloads (e.g. Union(A, B, C) producing anyOf: [{ anyOf: [A, B] }, C] instead of a single top-level anyOf). Request body schemas for union payloads now expose one flat anyOf array with all members, so clients and tooling see the correct union shape