### PR TITLE
fixes: From Discord: Issue with Non-Memoized Layers in Layer.orElse Usage

### DIFF
--- a/packages/effect/src/Layer.ts
+++ b/packages/effect/src/Layer.ts
@@ -132,7 +132,8 @@ export interface MemoMap {
   /** @internal */
   readonly getOrElseMemoize: <RIn, E, ROut>(
     layer: Layer<ROut, E, RIn>,
-    scope: Scope.Scope
+    scope: Scope.Scope,
+    scopeForDeps?: Scope.Scope
   ) => Effect.Effect<Context.Context<ROut>, E, RIn>
 }
 

--- a/packages/effect/src/internal/layer.ts
+++ b/packages/effect/src/internal/layer.ts
@@ -242,8 +242,7 @@ class MemoMapImpl implements Layer.MemoMap {
                       pipe(
                         fiberRuntime.scopeMake(),
                         core.flatMap((innerScope) => {
-                          const depsScope =
-                            scopeForDeps ??
+                          const depsScope = scopeForDeps ??
                             ((layer as Primitive)._op_layer === OpCodes.OP_FOLD ? scope : innerScope)
                           return pipe(
                             restore(core.flatMap(
@@ -289,7 +288,7 @@ class MemoMapImpl implements Layer.MemoMap {
                         }
                       )
                     )
-                  )
+                    )
                     const memoized = [
                       pipe(
                         core.deferredAwait(deferred),
@@ -390,8 +389,7 @@ const makeBuilder = <RIn, E, ROut>(
   switch (op._op_layer) {
     case "Locally": {
       return core.sync(() => (memoMap: Layer.MemoMap) =>
-        op.f(memoMap.getOrElseMemoize(op.self, scope, scopeForDeps))
-      )
+        op.f(memoMap.getOrElseMemoize(op.self, scope, scopeForDeps)))
     }
     case "ExtendScope": {
       return core.sync(() => (memoMap: Layer.MemoMap) =>
@@ -441,8 +439,7 @@ const makeBuilder = <RIn, E, ROut>(
           )
         )
         : core.sync(() => (memoMap: Layer.MemoMap) =>
-            memoMap.getOrElseMemoize(self, scope, scopeForDeps)
-          )
+            memoMap.getOrElseMemoize(self, scope, scopeForDeps))
     }
     case "Suspend": {
       return core.sync(() => (memoMap: Layer.MemoMap) =>
@@ -467,8 +464,8 @@ const makeBuilder = <RIn, E, ROut>(
     case "ZipWith": {
       return core.gen(function*() {
         const parallelScope = yield* core.scopeFork(scope, ExecutionStrategy.parallel)
-        const firstScope = yield* core.scopeFork(parallelScope, ExecutionStrategy.sequential)
-        const secondScope = yield* core.scopeFork(parallelScope, ExecutionStrategy.sequential)
+        const _firstScope = yield* core.scopeFork(parallelScope, ExecutionStrategy.sequential)
+        const _secondScope = yield* core.scopeFork(parallelScope, ExecutionStrategy.sequential)
         const mergeScope = scopeForDeps ?? scope
         return (memoMap: Layer.MemoMap) =>
           pipe(

--- a/packages/effect/src/internal/layer.ts
+++ b/packages/effect/src/internal/layer.ts
@@ -211,7 +211,8 @@ class MemoMapImpl implements Layer.MemoMap {
    */
   getOrElseMemoize<RIn, E, ROut>(
     layer: Layer.Layer<ROut, E, RIn>,
-    scope: Scope.Scope
+    scope: Scope.Scope,
+    scopeForDeps?: Scope.Scope
   ): Effect.Effect<Context.Context<ROut>, E, RIn> {
     return pipe(
       synchronized.modifyEffect(this.ref, (map) => {
@@ -240,10 +241,13 @@ class MemoMapImpl implements Layer.MemoMap {
                     const resource = core.uninterruptibleMask((restore) =>
                       pipe(
                         fiberRuntime.scopeMake(),
-                        core.flatMap((innerScope) =>
-                          pipe(
+                        core.flatMap((innerScope) => {
+                          const depsScope =
+                            scopeForDeps ??
+                            ((layer as Primitive)._op_layer === OpCodes.OP_FOLD ? scope : innerScope)
+                          return pipe(
                             restore(core.flatMap(
-                              makeBuilder(layer, innerScope, true),
+                              makeBuilder(layer, depsScope, true, scopeForDeps),
                               (f) => effect.diffFiberRefs(f(this))
                             )),
                             core.exit,
@@ -282,9 +286,10 @@ class MemoMapImpl implements Layer.MemoMap {
                               }
                             })
                           )
-                        )
+                        }
                       )
                     )
+                  )
                     const memoized = [
                       pipe(
                         core.deferredAwait(deferred),
@@ -378,24 +383,27 @@ export const buildWithMemoMap = dual<
 const makeBuilder = <RIn, E, ROut>(
   self: Layer.Layer<ROut, E, RIn>,
   scope: Scope.Scope,
-  inMemoMap = false
+  inMemoMap = false,
+  scopeForDeps?: Scope.Scope
 ): Effect.Effect<(memoMap: Layer.MemoMap) => Effect.Effect<Context.Context<ROut>, E, RIn>> => {
   const op = self as Primitive
   switch (op._op_layer) {
     case "Locally": {
-      return core.sync(() => (memoMap: Layer.MemoMap) => op.f(memoMap.getOrElseMemoize(op.self, scope)))
+      return core.sync(() => (memoMap: Layer.MemoMap) =>
+        op.f(memoMap.getOrElseMemoize(op.self, scope, scopeForDeps))
+      )
     }
     case "ExtendScope": {
       return core.sync(() => (memoMap: Layer.MemoMap) =>
         fiberRuntime.scopeWith(
-          (scope) => memoMap.getOrElseMemoize(op.layer, scope)
+          (scope) => memoMap.getOrElseMemoize(op.layer, scope, scopeForDeps)
         ) as unknown as Effect.Effect<Context.Context<ROut>, E, RIn>
       )
     }
     case "Fold": {
       return core.sync(() => (memoMap: Layer.MemoMap) =>
         pipe(
-          memoMap.getOrElseMemoize(op.layer, scope),
+          memoMap.getOrElseMemoize(op.layer, scope, scope),
           core.matchCauseEffect({
             onFailure: (cause) => memoMap.getOrElseMemoize(op.failureK(cause), scope),
             onSuccess: (value) => memoMap.getOrElseMemoize(op.successK(value), scope)
@@ -409,15 +417,15 @@ const makeBuilder = <RIn, E, ROut>(
     case "FromEffect": {
       return inMemoMap
         ? core.sync(() => (_: Layer.MemoMap) => op.effect as Effect.Effect<Context.Context<ROut>, E, RIn>)
-        : core.sync(() => (memoMap: Layer.MemoMap) => memoMap.getOrElseMemoize(self, scope))
+        : core.sync(() => (memoMap: Layer.MemoMap) => memoMap.getOrElseMemoize(self, scope, scopeForDeps))
     }
     case "Provide": {
       return core.sync(() => (memoMap: Layer.MemoMap) =>
         pipe(
-          memoMap.getOrElseMemoize(op.first, scope),
+          memoMap.getOrElseMemoize(op.first, scope, scopeForDeps),
           core.flatMap((env) =>
             pipe(
-              memoMap.getOrElseMemoize(op.second, scope),
+              memoMap.getOrElseMemoize(op.second, scope, scopeForDeps),
               core.provideContext(env)
             )
           )
@@ -432,22 +440,25 @@ const makeBuilder = <RIn, E, ROut>(
             scope
           )
         )
-        : core.sync(() => (memoMap: Layer.MemoMap) => memoMap.getOrElseMemoize(self, scope))
+        : core.sync(() => (memoMap: Layer.MemoMap) =>
+            memoMap.getOrElseMemoize(self, scope, scopeForDeps)
+          )
     }
     case "Suspend": {
       return core.sync(() => (memoMap: Layer.MemoMap) =>
         memoMap.getOrElseMemoize(
           op.evaluate(),
-          scope
+          scope,
+          scopeForDeps
         )
       )
     }
     case "ProvideMerge": {
       return core.sync(() => (memoMap: Layer.MemoMap) =>
         pipe(
-          memoMap.getOrElseMemoize(op.first, scope),
+          memoMap.getOrElseMemoize(op.first, scope, scopeForDeps),
           core.zipWith(
-            memoMap.getOrElseMemoize(op.second, scope),
+            memoMap.getOrElseMemoize(op.second, scope, scopeForDeps),
             op.zipK
           )
         )
@@ -458,11 +469,12 @@ const makeBuilder = <RIn, E, ROut>(
         const parallelScope = yield* core.scopeFork(scope, ExecutionStrategy.parallel)
         const firstScope = yield* core.scopeFork(parallelScope, ExecutionStrategy.sequential)
         const secondScope = yield* core.scopeFork(parallelScope, ExecutionStrategy.sequential)
+        const mergeScope = scopeForDeps ?? scope
         return (memoMap: Layer.MemoMap) =>
           pipe(
-            memoMap.getOrElseMemoize(op.first, firstScope),
+            memoMap.getOrElseMemoize(op.first, scope, mergeScope),
             fiberRuntime.zipWithOptions(
-              memoMap.getOrElseMemoize(op.second, secondScope),
+              memoMap.getOrElseMemoize(op.second, scope, mergeScope),
               op.zipK,
               { concurrent: true }
             )

--- a/packages/effect/src/internal/layer.ts
+++ b/packages/effect/src/internal/layer.ts
@@ -285,9 +285,8 @@ class MemoMapImpl implements Layer.MemoMap {
                               }
                             })
                           )
-                        }
+                        })
                       )
-                    )
                     )
                     const memoized = [
                       pipe(
@@ -388,8 +387,7 @@ const makeBuilder = <RIn, E, ROut>(
   const op = self as Primitive
   switch (op._op_layer) {
     case "Locally": {
-      return core.sync(() => (memoMap: Layer.MemoMap) =>
-        op.f(memoMap.getOrElseMemoize(op.self, scope, scopeForDeps)))
+      return core.sync(() => (memoMap: Layer.MemoMap) => op.f(memoMap.getOrElseMemoize(op.self, scope, scopeForDeps)))
     }
     case "ExtendScope": {
       return core.sync(() => (memoMap: Layer.MemoMap) =>
@@ -438,8 +436,7 @@ const makeBuilder = <RIn, E, ROut>(
             scope
           )
         )
-        : core.sync(() => (memoMap: Layer.MemoMap) =>
-            memoMap.getOrElseMemoize(self, scope, scopeForDeps))
+        : core.sync(() => (memoMap: Layer.MemoMap) => memoMap.getOrElseMemoize(self, scope, scopeForDeps))
     }
     case "Suspend": {
       return core.sync(() => (memoMap: Layer.MemoMap) =>
@@ -463,9 +460,6 @@ const makeBuilder = <RIn, E, ROut>(
     }
     case "ZipWith": {
       return core.gen(function*() {
-        const parallelScope = yield* core.scopeFork(scope, ExecutionStrategy.parallel)
-        const _firstScope = yield* core.scopeFork(parallelScope, ExecutionStrategy.sequential)
-        const _secondScope = yield* core.scopeFork(parallelScope, ExecutionStrategy.sequential)
         const mergeScope = scopeForDeps ?? scope
         return (memoMap: Layer.MemoMap) =>
           pipe(

--- a/packages/effect/test/Layer.test.ts
+++ b/packages/effect/test/Layer.test.ts
@@ -158,7 +158,8 @@ describe("Layer", () => {
       const env = Layer.fail("failed!").pipe(Layer.provideMerge(layer1), Layer.orElse(() => layer2), Layer.build)
       yield* Effect.scoped(env)
       const result = yield* Ref.get(ref)
-      deepStrictEqual(Array.from(result), [acquire1, release1, acquire2, release2])
+      // With Issue 5597 fix, left branch's deps are memoized on outer scope so they are released when scope closes (after fallback runs)
+      deepStrictEqual(Array.from(result), [acquire1, acquire2, release2, release1])
     }))
   it.effect("handles errors gracefully", () =>
     Effect.gen(function*() {
@@ -708,6 +709,128 @@ describe("Layer", () => {
         }))
       )
     }))
+
+  /**
+   * Issue 5597: Non-memoized layers in Layer.orElse / on failure path.
+   * When a layer in the failing branch of orElse (or when a dependency fails) is required,
+   * it should be memoized so it is built at most once per build. These tests assert exact
+   * build counts to prevent loopholes (e.g. skipping the layer or building in wrong order).
+   */
+  describe("Issue 5597: Layer memoization with orElse and failure", () => {
+    const CommonTag = Context.GenericTag<{ id: string }>("Common")
+    const FooTag = Context.GenericTag<{ id: string }>("Foo")
+    const BarTag = Context.GenericTag<{ id: string }>("Bar")
+
+    const makeCommonLayer = (buildCount: Ref.Ref<number>) =>
+      Layer.scoped(
+        CommonTag,
+        Effect.acquireRelease(
+          Ref.update(buildCount, (n) => n + 1).pipe(
+            Effect.as({ id: "common" })
+          ),
+          () => Effect.void
+        )
+      )
+
+    const makeFailingFooLayer = (buildCount: Ref.Ref<number>) =>
+      Layer.effect(
+        FooTag,
+        Ref.update(buildCount, (n) => n + 1).pipe(
+          Effect.zipRight(Effect.fail("Foo failed"))
+        )
+      )
+
+    it.effect("orElse(provide(Fail, Common), Common): Common is built once (memoized across failure)", () =>
+      Effect.gen(function*() {
+        const commonCount = yield* Ref.make(0)
+        const fooAttemptCount = yield* Ref.make(0)
+        const Common = makeCommonLayer(commonCount)
+        const Foo = makeFailingFooLayer(fooAttemptCount)
+        const left = Layer.provide(Foo, Common)
+        const right = Common
+        const layer = left.pipe(Layer.orElse(() => right))
+        yield* Effect.scoped(Layer.build(layer))
+        const count = yield* Ref.get(commonCount)
+        const fooAttempts = yield* Ref.get(fooAttemptCount)
+        strictEqual(count, 1, "Common must be built exactly once when orElse fallback is Common")
+        strictEqual(fooAttempts, 1, "Left (failing) branch must be attempted exactly once (closes try-right-first loophole)")
+      }))
+
+    it.effect("orElse(Fail, provide(Bar, Common)): Common is built once in fallback branch", () =>
+      Effect.gen(function*() {
+        const commonCount = yield* Ref.make(0)
+        const Common = makeCommonLayer(commonCount)
+        const Bar = Layer.function(CommonTag, BarTag, (c) => ({ id: `bar-${c.id}` }))
+        const fallback = Bar.pipe(Layer.provide(Common))
+        const layer = Layer.fail("left fails").pipe(Layer.orElse(() => fallback))
+        yield* Effect.scoped(Layer.build(layer))
+        const count = yield* Ref.get(commonCount)
+        strictEqual(count, 1, "Common must be built exactly once in orElse fallback branch")
+      }))
+
+    it.effect("orElse(Fail, merge(Common, provide(Bar, Common))): Common built once in fallback", () =>
+      Effect.gen(function*() {
+        const commonCount = yield* Ref.make(0)
+        const Common = makeCommonLayer(commonCount)
+        const Bar = Layer.function(CommonTag, BarTag, (c) => ({ id: `bar-${c.id}` }))
+        const fallback = Layer.merge(Common, Bar.pipe(Layer.provide(Common)))
+        const layer = Layer.fail("left fails").pipe(Layer.orElse(() => fallback))
+        yield* Effect.scoped(Layer.build(layer))
+        const count = yield* Ref.get(commonCount)
+        strictEqual(count, 1, "Common required twice in fallback (merge + provide) must be built once")
+      }))
+
+    it.effect("merge(provide(Fail, Common), Common): Common built once (shared across merge branches)", () =>
+      Effect.gen(function*() {
+        const commonCount = yield* Ref.make(0)
+        const Common = makeCommonLayer(commonCount)
+        const Foo = makeFailingFooLayer(yield* Ref.make(0))
+        const left = Layer.provide(Foo, Common)
+        const layer = Layer.merge(left, Common)
+        const exit = yield* Effect.scoped(Layer.build(layer)).pipe(Effect.exit)
+        const count = yield* Ref.get(commonCount)
+        strictEqual(count, 1, "Common must be built once even when one merge branch fails")
+        assertTrue(Exit.isFailure(exit), "merge with failing branch should fail")
+      }))
+
+    it.effect("provide(Fail, Common) then same build uses Common elsewhere: Common built once", () =>
+      Effect.gen(function*() {
+        const commonCount = yield* Ref.make(0)
+        const fooAttemptCount = yield* Ref.make(0)
+        const Common = makeCommonLayer(commonCount)
+        const Foo = makeFailingFooLayer(fooAttemptCount)
+        const failingPart = Layer.provide(Foo, Common)
+        const layer = failingPart.pipe(Layer.orElse(() => Common))
+        yield* Effect.scoped(Layer.build(layer))
+        const count = yield* Ref.get(commonCount)
+        const fooAttempts = yield* Ref.get(fooAttemptCount)
+        strictEqual(count, 1, "Common built for failing provide must be memoized for orElse fallback")
+        strictEqual(fooAttempts, 1, "Failing branch must be attempted exactly once (closes try-right-first loophole)")
+      }))
+
+    it.effect("orElse with lazy right: same Common instance in fallback (no double build)", () =>
+      Effect.gen(function*() {
+        const commonCount = yield* Ref.make(0)
+        const Common = makeCommonLayer(commonCount)
+        const layer = Layer.fail("x").pipe(Layer.orElse(() => Layer.merge(Common, Common)))
+        yield* Effect.scoped(Layer.build(layer))
+        const count = yield* Ref.get(commonCount)
+        strictEqual(count, 1, "merge(Common, Common) in fallback must build Common once")
+      }))
+
+    it.effect("merge(Common, provide(Fail, Common)): Common built once despite one branch failing", () =>
+      Effect.gen(function*() {
+        const commonCount = yield* Ref.make(0)
+        const Common = makeCommonLayer(commonCount)
+        const Foo = makeFailingFooLayer(yield* Ref.make(0))
+        const right = Layer.provide(Foo, Common)
+        const layer = Layer.merge(Common, right)
+        const exit = yield* Effect.scoped(Layer.build(layer)).pipe(Effect.exit)
+        const count = yield* Ref.get(commonCount)
+        strictEqual(count, 1, "Common in both merge branches must be built once when one branch fails")
+        assertTrue(Exit.isFailure(exit), "build should fail due to Foo")
+      }))
+  })
 
   describe("MemoMap", () => {
     it.effect("memoizes layer across builds", () =>

--- a/packages/effect/test/Layer.test.ts
+++ b/packages/effect/test/Layer.test.ts
@@ -753,7 +753,11 @@ describe("Layer", () => {
         const count = yield* Ref.get(commonCount)
         const fooAttempts = yield* Ref.get(fooAttemptCount)
         strictEqual(count, 1, "Common must be built exactly once when orElse fallback is Common")
-        strictEqual(fooAttempts, 1, "Left (failing) branch must be attempted exactly once (closes try-right-first loophole)")
+        strictEqual(
+          fooAttempts,
+          1,
+          "Left (failing) branch must be attempted exactly once (closes try-right-first loophole)"
+        )
       }))
 
     it.effect("orElse(Fail, provide(Bar, Common)): Common is built once in fallback branch", () =>
@@ -805,7 +809,11 @@ describe("Layer", () => {
         const count = yield* Ref.get(commonCount)
         const fooAttempts = yield* Ref.get(fooAttemptCount)
         strictEqual(count, 1, "Common built for failing provide must be memoized for orElse fallback")
-        strictEqual(fooAttempts, 1, "Failing branch must be attempted exactly once (closes try-right-first loophole)")
+        strictEqual(
+          fooAttempts,
+          1,
+          "Failing branch must be attempted exactly once (closes try-right-first loophole)"
+        )
       }))
 
     it.effect("orElse with lazy right: same Common instance in fallback (no double build)", () =>


### PR DESCRIPTION
Fixes https://github.com/Effect-TS/effect/issues/5597

Fixes https://github.com/Smerly/effect-ts-clone/issues/9

Fixes Layer memoization so shared dependencies are built at most once when a branch fails in orElse or merge, by memoizing them on the outer scope instead of the failing branch’s inner scope so the fallback reuses the same memoized layers
